### PR TITLE
設定の遅延ロードと getter command 対応

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@ MySQL と PostgreSQL に接続してクエリを実行できる MCP サーバー
 - MySQL と PostgreSQL の両方をサポート
 - SSH トンネル経由での接続サポート
 - MCP サーバーまたは CLI から SQL クエリを実行
-- `config.yaml` または `SQL_AGENT_CONFIG_YAML` 環境変数による設定
+- `config.yaml`、`SQL_AGENT_CONFIG_YAML`、または秘密マネージャー向けの遅延 getter コマンド (`SQL_AGENT_CONFIG_YAML_GETTER_COMMAND`) による設定
 
 ## インストール
 
@@ -25,7 +25,25 @@ uv sync
 
 ## 設定
 
-`config.yaml` ファイルを作成して、接続するデータベースサーバーの情報を設定します。`SQL_AGENT_CONFIG_YAML` 環境変数で YAML 文字列を直接渡すこともできます (環境変数が優先)。
+`config.yaml` ファイルを作成して、接続するデータベースサーバーの情報を設定します。設定は次の優先順で解決されます:
+
+1. `SQL_AGENT_CONFIG_YAML` — YAML 文字列をインライン指定 (最優先)
+2. `SQL_AGENT_CONFIG_YAML_GETTER_COMMAND` — stdout が YAML 設定になるコマンド (遅延実行。後述)
+3. プロジェクトディレクトリの `config.yaml` ファイル
+
+#### 設定の遅延ロード (`SQL_AGENT_CONFIG_YAML_GETTER_COMMAND`)
+
+設定を秘密マネージャー (例: 1Password) に置いている場合、秘密そのものではなく **取得コマンド** を渡せます:
+
+```sh
+export SQL_AGENT_CONFIG_YAML_GETTER_COMMAND='op read "op://development/sql-agent/config-yaml"'
+```
+
+このコマンドは **起動時には実行されません**。実際に設定が必要になった時 — つまり最初の `list_sql_servers` / `execute_sql` 呼び出し時 — にだけ実行されます。これにより、MCP クライアント (例: Claude Desktop) がサーバーを起動するたびに 1Password 等の認証ダイアログが出るのを防げます。
+
+コマンドは `shlex.split` で分解し `shell=False` で実行します (シェルを介さない)。そのためシェルメタ文字によるインジェクションは起きませんが、パイプ・リダイレクト・変数展開は **使えません**。シェル機能が必要な場合はラッパースクリプトを 1 コマンドとして渡してください。
+
+起動時に認証せずともツール説明にサーバー一覧を表示できるよう、初回ロード成功後に **機密を含まないメタデータキャッシュ** (サーバーの `name` / `description` / `engine` / `host` / `port` / `schema` と `log_file_path`) を保存します。パスワードや SSH 秘密鍵は **キャッシュしません**。キャッシュパスは既定で `~/.cache/sql-agent-mcp-server/server-metadata.json`、`SQL_AGENT_CONFIG_CACHE_PATH` で変更できます。
 
 ```yaml
 # 任意: ログファイルのパス

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An MCP server that connects to MySQL and PostgreSQL databases to execute queries
 - Support for both MySQL and PostgreSQL
 - SSH tunnel connection support
 - Execute SQL queries via MCP server or CLI
-- Configuration via `config.yaml` or `SQL_AGENT_CONFIG_YAML` environment variable
+- Configuration via `config.yaml`, `SQL_AGENT_CONFIG_YAML`, or a lazy getter command (`SQL_AGENT_CONFIG_YAML_GETTER_COMMAND`) for secret managers
 
 ## Installation
 
@@ -29,7 +29,25 @@ uv sync
 
 ## Configuration
 
-Create a `config.yaml` file to configure database server connection information. Alternatively, the entire YAML can be provided inline via the `SQL_AGENT_CONFIG_YAML` environment variable (takes precedence over the file).
+Create a `config.yaml` file to configure database server connection information. Config is resolved in this order:
+
+1. `SQL_AGENT_CONFIG_YAML` — inline YAML string (highest precedence)
+2. `SQL_AGENT_CONFIG_YAML_GETTER_COMMAND` — a command whose stdout is the YAML config (run lazily; see below)
+3. `config.yaml` file in the project directory
+
+#### Lazy config loading (`SQL_AGENT_CONFIG_YAML_GETTER_COMMAND`)
+
+If your config lives in a secret manager (e.g. 1Password), pass the *command* that fetches it instead of the secret itself:
+
+```sh
+export SQL_AGENT_CONFIG_YAML_GETTER_COMMAND='op read "op://development/sql-agent/config-yaml"'
+```
+
+The command is **not** run at startup. It runs only when config is first actually needed — i.e. on the first `list_sql_servers` / `execute_sql` call. This avoids triggering a 1Password (etc.) authentication prompt every time the MCP client (e.g. Claude Desktop) launches the server.
+
+The command is split with `shlex.split` and executed with `shell=False` (no shell), so shell metacharacters cannot cause injection — but pipes, redirects, and variable expansion are **not** supported. Provide a single command (a wrapper script if you need shell features).
+
+To still show the server list in the tool descriptions without authenticating at startup, a **non-sensitive metadata cache** (server `name` / `description` / `engine` / `host` / `port` / `schema`, plus `log_file_path`) is written after the first successful load. Passwords and SSH private keys are **never** cached. Cache path defaults to `~/.cache/sql-agent-mcp-server/server-metadata.json` and can be overridden with `SQL_AGENT_CONFIG_CACHE_PATH`.
 
 ```yaml
 # Optional: log file path

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,40 +1,37 @@
 """
 SQL Agent の設定ローダー。
 
-SQL_AGENT_CONFIG_YAML 環境変数があればその YAML 文字列を、
-無ければ同ディレクトリの config.yaml を読み込んで dict で返す。
+設定 (YAML) の解決順:
+    1. SQL_AGENT_CONFIG_YAML 環境変数 (YAML 文字列リテラル)
+    2. SQL_AGENT_CONFIG_YAML_GETTER_COMMAND 環境変数 (実行して stdout を YAML として使う)
+    3. 同ディレクトリの config.yaml ファイル
+
+2 番の getter command は「秘密の取得コマンド (例: `op read op://...`)」を
+環境変数に置いておき、実際に config が必要になった時だけ実行することを想定する。
+これにより MCP サーバー起動時ではなく、ツール呼び出し時まで 1Password 等の
+認証を遅延できる。コマンドは shlex.split で argv に分解し shell=False で実行する
+(シェルを介さないのでパイプ/リダイレクト/変数展開は不可。単一コマンド前提)。
+
+機密を含まないサーバーメタデータ (name / description / engine / host / port /
+schema / log_file_path) のみをローカルにキャッシュする仕組みも提供する。
+これは起動時の instructions / tool description / ログパス設定に使い、
+パスワードや SSH 秘密鍵はキャッシュしない。
 """
+import json
 import os
+import shlex
+import subprocess
 from typing import Any
 
 import yaml
 
 
-def load_config(config_filename: str = 'config.yaml') -> dict[str, Any]:
-    """
-    設定を読み込んで dict で返す。
-
-    SQL_AGENT_CONFIG_YAML 環境変数が設定されていればそれを YAML として
-    パースし、無ければ このモジュールと同ディレクトリの config.yaml を読む。
-    """
-    config_yaml_env = os.environ.get('SQL_AGENT_CONFIG_YAML')
-    if config_yaml_env:
-        source = 'SQL_AGENT_CONFIG_YAML 環境変数'
-        try:
-            data = yaml.safe_load(config_yaml_env)
-        except yaml.YAMLError as e:
-            raise ValueError(f"{source} の YAML パースに失敗: {e}") from e
-    else:
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        config_path = os.path.join(current_dir, config_filename)
-        source = config_path
-        if not os.path.exists(config_path):
-            raise FileNotFoundError(f"Config file not found: {config_path}")
-        with open(config_path, 'r', encoding='utf-8') as f:
-            try:
-                data = yaml.safe_load(f)
-            except yaml.YAMLError as e:
-                raise ValueError(f"{source} の YAML パースに失敗: {e}") from e
+def _parse_yaml(yaml_text: str, source: str) -> dict[str, Any]:
+    """YAML 文字列をパースして dict を返す。検証付き。"""
+    try:
+        data = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as e:
+        raise ValueError(f"{source} の YAML パースに失敗: {e}") from e
 
     if not data:
         raise ValueError(f"Config is empty: {source}")
@@ -45,4 +42,165 @@ def load_config(config_filename: str = 'config.yaml') -> dict[str, Any]:
             f" {source}"
         )
 
+    return data
+
+
+def _run_getter_command(command: str) -> str:
+    """
+    getter command を実行して stdout を返す。
+
+    `op read "op://..."` を shlex.split で argv に分解し、shell=False で実行する。
+    shell を介さないため、コマンド文字列に `;` `|` `$()` 等が混入しても
+    シェルメタ文字として解釈されず、コマンドインジェクションの余地が無い。
+    その代わりパイプ・リダイレクト・変数展開は使えない (単一コマンド前提)。
+    """
+    try:
+        argv = shlex.split(command)
+    except ValueError as e:
+        # クォートが閉じていない等で分解に失敗
+        raise ValueError(
+            f"SQL_AGENT_CONFIG_YAML_GETTER_COMMAND の解析に失敗"
+            f" (クォート不整合等): {command!r}: {e}"
+        ) from e
+    if not argv:
+        raise ValueError(
+            "SQL_AGENT_CONFIG_YAML_GETTER_COMMAND が空です"
+        )
+
+    try:
+        result = subprocess.run(
+            argv,
+            shell=False,
+            capture_output=True,
+            text=True,
+            # 認証待ち等で無限ハングするとツール呼び出しが固まるので timeout 必須。
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise ValueError(
+            f"SQL_AGENT_CONFIG_YAML_GETTER_COMMAND がタイムアウト"
+            f" ({e.timeout}秒): {command!r}"
+            f" (1Password 等の認証待ちでハングしている可能性)"
+        ) from e
+    except Exception as e:
+        raise ValueError(
+            f"SQL_AGENT_CONFIG_YAML_GETTER_COMMAND の実行に失敗:"
+            f" {command!r}: {e}"
+        ) from e
+
+    if result.returncode != 0:
+        raise ValueError(
+            f"SQL_AGENT_CONFIG_YAML_GETTER_COMMAND が異常終了"
+            f" (code={result.returncode}): {command!r}\n"
+            f"stderr: {result.stderr.strip()}"
+        )
+
+    if not result.stdout.strip():
+        raise ValueError(
+            f"SQL_AGENT_CONFIG_YAML_GETTER_COMMAND の出力が空: {command!r}"
+        )
+
+    return result.stdout
+
+
+def load_config(config_filename: str = 'config.yaml') -> dict[str, Any]:
+    """
+    設定を読み込んで dict で返す。
+
+    解決順はモジュール docstring を参照。getter command が設定されている
+    場合はここで実行されるため、この関数の呼び出しが 1Password 等の認証を
+    トリガーしうる点に注意 (= 起動時ではなく実際に config が要る時に呼ぶ)。
+    """
+    config_yaml_env = os.environ.get('SQL_AGENT_CONFIG_YAML')
+    if config_yaml_env:
+        return _parse_yaml(config_yaml_env, 'SQL_AGENT_CONFIG_YAML 環境変数')
+
+    getter_command = os.environ.get('SQL_AGENT_CONFIG_YAML_GETTER_COMMAND')
+    if getter_command:
+        yaml_text = _run_getter_command(getter_command)
+        return _parse_yaml(
+            yaml_text,
+            f'SQL_AGENT_CONFIG_YAML_GETTER_COMMAND ({getter_command})',
+        )
+
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(current_dir, config_filename)
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+    with open(config_path, 'r', encoding='utf-8') as f:
+        return _parse_yaml(f.read(), config_path)
+
+
+# -- 機密を含まないサーバーメタデータのローカルキャッシュ --
+
+# キャッシュに残してよいサーバー項目 (パスワード / SSH 秘密鍵は含めない)。
+_CACHEABLE_SERVER_KEYS = (
+    'name',
+    'description',
+    'engine',
+    'host',
+    'port',
+    'schema',
+)
+
+DEFAULT_CACHE_PATH = os.path.expanduser(
+    '~/.cache/sql-agent-mcp-server/server-metadata.json'
+)
+
+
+def get_cache_path() -> str:
+    """メタデータキャッシュのパス。環境変数で上書き可能。"""
+    return os.environ.get('SQL_AGENT_CONFIG_CACHE_PATH', DEFAULT_CACHE_PATH)
+
+
+def _sanitize_for_cache(config: dict[str, Any]) -> dict[str, Any]:
+    """config から機密を除いた、起動時に必要なメタデータだけを抽出する。"""
+    servers = []
+    for server in config.get('sql_servers', []):
+        servers.append(
+            {k: server[k] for k in _CACHEABLE_SERVER_KEYS if k in server}
+        )
+    cached: dict[str, Any] = {'sql_servers': servers}
+    if config.get('log_file_path'):
+        cached['log_file_path'] = config['log_file_path']
+    return cached
+
+
+def save_metadata_cache(config: dict[str, Any]) -> None:
+    """
+    機密を除いたサーバーメタデータをローカルキャッシュに保存する。
+    保存失敗は致命的ではないので握りつぶす (best-effort)。
+    """
+    cache_path = get_cache_path()
+    try:
+        cache_dir = os.path.dirname(cache_path)
+        os.makedirs(cache_dir, exist_ok=True)
+        # ディレクトリも owner のみ (0o700) にし、path 存在の列挙を防ぐ。
+        # makedirs の mode は umask の影響を受けるので chmod で確実に締める。
+        os.chmod(cache_dir, 0o700)
+        # host / port / schema 等が他ユーザーに読まれないよう owner のみ (0o600)。
+        fd = os.open(
+            cache_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+        )
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(_sanitize_for_cache(config), f, ensure_ascii=False)
+    except Exception:
+        # キャッシュは best-effort。失敗してもアプリは動く。
+        pass
+
+
+def load_metadata_cache() -> dict[str, Any] | None:
+    """
+    保存済みメタデータキャッシュを読み込む。無い / 壊れている場合は None。
+    """
+    cache_path = get_cache_path()
+    if not os.path.exists(cache_path):
+        return None
+    try:
+        with open(cache_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
     return data

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4,6 +4,7 @@ MCP server for connecting to MySQL and PostgreSQL databases
 """
 
 import json
+import os
 import sys
 from textwrap import dedent
 from typing import Annotated
@@ -11,28 +12,46 @@ from typing import Annotated
 import fastmcp
 from pydantic import Field
 
-from config_loader import load_config
+from config_loader import load_config, load_metadata_cache
 from logging_config import logger, setup_logger_for_mcp_server
 from sql_agent import SQLAgentManager
 
 
-def build_server(config: dict) -> fastmcp.FastMCP:
-    """config から FastMCP サーバーインスタンスを構築してツールを登録する。
+def build_server() -> fastmcp.FastMCP:
+    """FastMCP サーバーインスタンスを構築してツールを登録する。
 
-    SQLAgentManager もここで作り、ツールハンドラからクロージャー越しに参照する。
-    モジュールグローバルを介さないので、テストやマルチ起動でも独立に動く。
+    config 本体 (パスワード等を含む) はここでは読み込まない。getter command
+    経由だと起動時に 1Password 認証が走ってしまうため。代わりに、機密を含まない
+    ローカルメタデータキャッシュ (前回ロード時に保存) から server_name 一覧を
+    instructions / tool description に埋め込む。キャッシュが無い初回起動時は
+    一覧が空になるが、LLM が list_sql_servers を呼べば実際の config が遅延ロード
+    される (このタイミングで初めて認証が走る)。
+
+    SQLAgentManager には load_config を loader として渡し、初回ツール呼び出し時に
+    遅延ロードさせる。
     """
-    sql_servers = config.get('sql_servers', [])
-    sql_server_names = [server['name'] for server in sql_servers]
-    sql_server_name_and_description = '\n\n'.join(
-        [
-            f"## server_name: {server['name']}\n\n"
-            f"{server.get('description', '')}"
-            for server in sql_servers
-        ]
-    )
+    cache = load_metadata_cache() or {}
+    cached_servers = cache.get('sql_servers', [])
+    # キャッシュが手動編集等で壊れて name 欠落があっても起動を止めない。
+    sql_server_names = [
+        server['name'] for server in cached_servers if server.get('name')
+    ]
+    if sql_server_names:
+        sql_server_name_and_description = '\n\n'.join(
+            [
+                f"## server_name: {server['name']}\n\n"
+                f"{server.get('description', '')}"
+                for server in cached_servers
+                if server.get('name')
+            ]
+        )
+    else:
+        sql_server_name_and_description = (
+            "(まだサーバー一覧をロードしていません。"
+            "list_sql_servers ツールを呼ぶと取得できます。)"
+        )
 
-    manager = SQLAgentManager(sql_servers)
+    manager = SQLAgentManager(load_config)
 
     server = fastmcp.FastMCP(
         name="sql-agent-mcp-server",
@@ -45,6 +64,9 @@ def build_server(config: dict) -> fastmcp.FastMCP:
             テーブルの構造を読むことはできます。
 
             # SQL サーバー の名前 (server_name) と説明
+
+            下記はローカルキャッシュに基づく一覧です。最新の一覧は
+            list_sql_servers ツールで取得してください。
 
             {sql_server_name_and_description}
             """
@@ -139,27 +161,27 @@ def build_server(config: dict) -> fastmcp.FastMCP:
 def main() -> None:
     """メイン関数: MCPサーバーを起動します"""
 
-    # 起動エラーもログに残るよう、デフォルトパス (or 環境変数) で先にロガーを
-    # 初期化する。
-    setup_logger_for_mcp_server()
-
-    try:
-        config = load_config()
-    except Exception as e:
-        error_msg = f"❌ エラー: 設定の読み込みに失敗しました: {e}"
-        logger.error(error_msg)
-        print(error_msg, file=sys.stderr)
-        sys.exit(1)
-
-    # config に log_file_path があれば再設定 (パスが違えば差し替え)
-    if config.get('log_file_path'):
-        setup_logger_for_mcp_server(config['log_file_path'])
+    # 起動時は config 本体 (パスワード等) を読み込まない。getter command 経由だと
+    # 起動時に 1Password 認証が走ってしまうため、実際の config ロードは最初の
+    # ツール呼び出しまで遅延させる (SQLAgentManager._ensure_loaded)。
+    #
+    # ログパスの解決順:
+    #   1. 環境変数 SQL_AGENT_LOG_FILE_PATH
+    #   2. メタデータキャッシュの log_file_path (前回ロード時に保存)
+    #   3. デフォルトパス
+    # config (YAML) 内の log_file_path は初回ロード後に再設定される。
+    cache = load_metadata_cache() or {}
+    cached_log_path = cache.get('log_file_path')
+    if not os.environ.get('SQL_AGENT_LOG_FILE_PATH') and cached_log_path:
+        setup_logger_for_mcp_server(cached_log_path)
+    else:
+        setup_logger_for_mcp_server()
 
     logger.info("MCP サーバー起動中...")
 
     try:
-        server = build_server(config)
-        logger.info("SQL Agent Manager を初期化しました")
+        server = build_server()
+        logger.info("SQL Agent Manager を初期化しました (config は遅延ロード)")
     except Exception as e:
         error_msg = f"❌ エラー: MCP サーバーの構築に失敗しました: {e}"
         logger.error(error_msg)

--- a/sql_agent.py
+++ b/sql_agent.py
@@ -8,7 +8,7 @@ import os
 import re
 from contextlib import contextmanager
 from datetime import date, datetime
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 import psycopg2
 import psycopg2.extras
@@ -16,7 +16,8 @@ import pymysql
 import pymysql.cursors
 from sshtunnel import SSHTunnelForwarder
 
-from logging_config import logger
+from config_loader import save_metadata_cache
+from logging_config import logger, setup_logger_for_mcp_server
 
 # SQL の文字列リテラル '...' を ログ出力時にマスクする正規表現。
 # 単一引用符の中身は次の 3 通りを許容:
@@ -25,10 +26,19 @@ from logging_config import logger
 #   3. '' (二重シングルクォートでのエスケープ; PostgreSQL / 標準 SQL)
 _SQL_STRING_LITERAL_RE = re.compile(r"'(?:[^'\\]|\\.|'')*'")
 
+# PostgreSQL のドルクォート文字列をマスクする正規表現。
+# 開始/終了のタグが一致する必要があるため後方参照 (\1) を使う:
+#   - タグ無し: $$...$$ (\1 は空文字にマッチ)
+#   - タグ付き: $tag$...$tag$
+# 本文は改行を含みうるので [\s\S] で全文字を非貪欲にマッチさせる。
+_SQL_DOLLAR_QUOTE_RE = re.compile(r"\$(\w*)\$[\s\S]*?\$\1\$")
+
 
 def mask_sql_for_log(sql: str) -> str:
     """ログ出力用に SQL の文字列リテラルをマスクする (PII / 機密漏れ防止)"""
-    return _SQL_STRING_LITERAL_RE.sub("'***'", sql)
+    # ドルクォートを先にマスクする (本文に ' を含んでいても丸ごと潰すため)。
+    masked = _SQL_DOLLAR_QUOTE_RE.sub("$$***$$", sql)
+    return _SQL_STRING_LITERAL_RE.sub("'***'", masked)
 
 
 class SQLAgent:
@@ -330,17 +340,49 @@ class SQLAgent:
 class SQLAgentManager:
     """複数の SQL Agent を管理するクラス"""
 
-    def __init__(self, servers_config: List[Dict[str, Any]]):
+    def __init__(self, config_loader: Callable[[], Dict[str, Any]]):
         """
         Args:
-            servers_config: サーバー設定のリスト
+            config_loader: config (dict) を返す callable。実際に config が
+                必要になった初回アクセス時に一度だけ呼ばれる。getter command
+                経由の場合、この呼び出しが 1Password 等の認証をトリガーする。
         """
-        self.servers_config = servers_config
+        self._config_loader = config_loader
+        self._loaded = False
+        self.servers_config: List[Dict[str, Any]] = []
+        self.server_configs: Dict[str, Dict[str, Any]] = {}
         self.agents = {}
-        # サーバー名からサーバー設定を取得するための辞書を作成
+
+    def _ensure_loaded(self) -> None:
+        """config を初回アクセス時に一度だけロードする (memoize)。"""
+        if self._loaded:
+            return
+
+        config = self._config_loader()
+        self.servers_config = config.get('sql_servers', [])
         self.server_configs = {
-            config['name']: config for config in servers_config
+            server['name']: server for server in self.servers_config
         }
+
+        # ロード成功時に、機密を除いたメタデータをキャッシュ更新する。
+        # 次回起動時の instructions / ログパスに使われる (best-effort)。
+        save_metadata_cache(config)
+
+        # YAML に log_file_path があればログ設定を差し替える
+        # (起動時はキャッシュ or 環境変数のパス、初回ロード後に正規パスへ)。
+        # ただしログ設定の失敗で config ロード全体を巻き戻すと、次回呼び出しで
+        # 再び _config_loader() が走り 1Password 認証が毎回出るループになる。
+        # config 自体は読めているので、ログ差し替えは best-effort とし、
+        # 失敗しても起動時に設定済みの (動作中の) ロガーで続行する。
+        if config.get('log_file_path'):
+            try:
+                setup_logger_for_mcp_server(config['log_file_path'])
+            except Exception as e:
+                logger.warning(
+                    f"log_file_path への切り替えに失敗 (既存ロガーで続行): {e}"
+                )
+
+        self._loaded = True
 
     def get_agent(self, server_name: str) -> SQLAgent:
         """
@@ -353,6 +395,7 @@ class SQLAgentManager:
         Returns:
             SQL Agent インスタンス
         """
+        self._ensure_loaded()
         if server_name not in self.server_configs:
             raise ValueError(f"Server not found: {server_name}")
 
@@ -372,6 +415,7 @@ class SQLAgentManager:
         Returns:
             サーバー情報のリスト
         """
+        self._ensure_loaded()
         servers = []
         for config in self.servers_config:
             servers.append(

--- a/sql_agent_cli.py
+++ b/sql_agent_cli.py
@@ -35,12 +35,12 @@ def _read_sql_from_stdin_or_arg(sql_arg: str | None) -> str:
 
 
 def _build_manager() -> SQLAgentManager:
-    # まずデフォルトパスでロガーを初期化 (load_config 失敗時にもログを残す)
+    # まずデフォルトパスでロガーを初期化 (load_config 失敗時にもログを残す)。
+    # CLI は明示的に実行されるので、起動時に config をロードして認証が走っても
+    # 問題ない。SQLAgentManager が初回アクセス時に load_config を呼び、
+    # log_file_path の再設定とメタデータキャッシュ更新も行う。
     setup_logger_for_mcp_server()
-    config = load_config()
-    if config.get('log_file_path'):
-        setup_logger_for_mcp_server(config['log_file_path'])
-    return SQLAgentManager(config.get('sql_servers', []))
+    return SQLAgentManager(load_config)
 
 
 # -- subcommand handlers --

--- a/test-requests/test-mcp-list-sql-servers.sh
+++ b/test-requests/test-mcp-list-sql-servers.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env zsh
+# list_sql_servers ツールを呼び出して登録済み SQL サーバー一覧を取得する
+
+cd $(dirname $0)/../
+
+source ./.loadenv.sh
+
+# MCP は initialize → notifications/initialized → tools/call の順で送る。
+# ツールは "tools/call" メソッドで呼び、ツール名は params.name に渡す。
+{
+    echo '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
+    sleep 0.5
+    echo '{"jsonrpc": "2.0", "method": "notifications/initialized"}'
+    sleep 0.5
+    echo '{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "list_sql_servers", "arguments": {}}}'
+    sleep 1
+} | ./launch-mcp-server.sh | jq


### PR DESCRIPTION
## 概要

MCP サーバー起動時に 1Password CLI 認証が走るのを避けるため、config の読み込みを遅延化する。

## 変更点

- `SQL_AGENT_CONFIG_YAML_GETTER_COMMAND` で取得コマンド文字列を渡し、初回ツール呼び出し時にだけ実行 (`shlex.split` + `shell=False`、インジェクション面なし)
- 機密を含まないメタデータのみローカルキャッシュ (file `0600` / dir `0700`)。パスワード・SSH 秘密鍵はキャッシュしない
- `SQLAgentManager` を遅延ロード対応 (callable を受け取り memoize)。ログ再設定は best-effort 化し再認証ループを防止
- PostgreSQL ドルクォート文字列 (`$$...$$`) のログマスク対応
- `test-mcp-list-sql-servers.sh` の JSON-RPC 呼び出しを修正 (`tools/call` 形式に)

## レビュー

Codex + code-reviewer による2周のレビュー実施済み。指摘された timeout・権限・再認証ループ・インジェクション面を修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)